### PR TITLE
Enable GPU/NPU for IMX8MP

### DIFF
--- a/recipes-extended/ubuntu/ubuntu-base-image.inc
+++ b/recipes-extended/ubuntu/ubuntu-base-image.inc
@@ -82,7 +82,7 @@ glib-2.0 glib-networking gobject-introspection  \
 gobject-introspection-dev gsettings-desktop-schemas-dev gtk+3-dev gtk+-dev \
 hicolor-icon-theme i2c-tools ibxshmfence-dev icu icu-dev  \
 ifenslave init-system-helpers-service iproute2-ip iso-codes-dev  \
-lame lame-dev libasm1 libasound2 libatk-1.0-0 libatk-bridge-2.0-0  \
+lame lame-dev libasm1 libatk-1.0-0 libatk-bridge-2.0-0  \
 libatomic-dev libatomic-ops libatomic-ops-dev libatopology2  \
 libatspi0 libattr1 libavahi-client3 libavahi-common3  \
 libavahi-core7 libavahi-glib1 libavahi-gobject0  \

--- a/recipes-extended/ubuntu/ubuntu-base_24.04.1.bb
+++ b/recipes-extended/ubuntu/ubuntu-base_24.04.1.bb
@@ -64,7 +64,7 @@ glib-2.0 glib-networking gobject-introspection  \
 gobject-introspection-dev gsettings-desktop-schemas-dev gtk+3-dev gtk+-dev \
 hicolor-icon-theme i2c-tools ibxshmfence-dev icu icu-dev  \
 ifenslave init-system-helpers-service iproute2-ip iso-codes-dev  \
-lame lame-dev libasm1 libasound2 libatk-1.0-0 libatk-bridge-2.0-0  \
+lame lame-dev libasm1 libatk-1.0-0 libatk-bridge-2.0-0  \
 libatomic-dev libatomic-ops libatomic-ops-dev libatopology2  \
 libatspi0 libattr1 libavahi-client3 libavahi-common3  \
 libavahi-core7 libavahi-glib1 libavahi-gobject0  \

--- a/recipes-fsl/images/imx-image-desktop.bb
+++ b/recipes-fsl/images/imx-image-desktop.bb
@@ -188,6 +188,10 @@ IMAGE_INSTALL += "\
 	gstreamer1.0-plugins-base-videotestsrc \
 	gstreamer1.0-plugins-base-ximagesink \
 	gstreamer1.0-plugins-base-xvimagesink \
+	libopenvx-imx libopenvx-imx-dev \
+	libnn-imx \
+	tensorflow-lite \
+	tensorflow-lite-vx-delegate \ 
 "
 
 # gstreamer1.0-plugins-good-ximagesrc libxtst6
@@ -197,6 +201,7 @@ IMAGE_INSTALL += "\
 
 APTGET_EXTRA_PACKAGES += "\
 	ntpdate patchelf \
+	python3-numpy python3-pil \
 "
 
 ##############################################################################
@@ -382,7 +387,7 @@ IMAGE_INSTALL:remove:imx95-19x19-lpddr5-evk = " \
     libnn-imx \
     tensorflow-lite \
     tensorflow-lite-vx-delegate \
-    ${ML_NNSTREAMER_PKGS} \
+	${ML_NNSTREAMER_PKGS} \
 "
 
 fakeroot do_save_cheese() {
@@ -395,3 +400,5 @@ fakeroot do_save_cheese() {
 
 	set +x
 }
+
+PACKAGE_EXCLUDE = "libgles3-imx-dev libegl-imx-dev libc6-dev"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -72,12 +72,6 @@ if ! grep -q 'PACKAGE_CLASSES = "package_rpm"' local.conf
 then
 sed -i 's/^PACKAGE_CLASSES =.*/PACKAGE_CLASSES = "package_rpm"/' local.conf
 fi
-if ! grep -q 'DISTRO_FEATURES:remove = " wayland alsa"' local.conf
-then
-cat >> local.conf <<EOF
-DISTRO_FEATURES:remove = " wayland alsa"
-EOF
-fi
 if ! grep -q 'PARALLEL_MAKE =' local.conf
 then
 cat >> local.conf <<EOF


### PR DESCRIPTION
Add wayland & alsa back into distro features.
Fix compilation with GPU & NPU

To test NPU use

```
export PYTHONPATH=$PYTHONPATH:/usr/lib/python3.12/site-packages
cd /usr/bin/tensorflow-lite-2.15.0/examples
python3 label_image.py --ext_delegate=/usr/lib/libvx_delegate.so
```

Open thing is still that the TF installation isn't int the default python include path.