### PR TITLE
Make mavlink router launch conditional

### DIFF
--- a/recipes-fsl/images/imx-image-ros.bb
+++ b/recipes-fsl/images/imx-image-ros.bb
@@ -9,6 +9,8 @@ SRC_URI = " \
 
 IMAGE_INSTALL += "\
     install-interface-config \
+    mavlink-router \
+    remoteidtransmitter \
 "
 
 ROS_VERSION = "jazzy"

--- a/recipes-support/mavlink-router/mavlink-router_1.0.bb
+++ b/recipes-support/mavlink-router/mavlink-router_1.0.bb
@@ -19,8 +19,13 @@ S = "${WORKDIR}/git"
 SYSTEMD_SERVICE:${PN} = "mavlink-router.service"
 
 do_install:append() {
-    install -d ${D}/etc/mavlink-router/
-    install -p -m 755 ${WORKDIR}/main.conf ${D}/etc/mavlink-router/
+    install -d ${D}${sysconfdir}/mavlink-router
+    install -m 755 ${UNPACKDIR}/main.conf ${D}${sysconfdir}/mavlink-router/main.conf
+    SERVICE_FILE="${D}${systemd_system_unitdir}/mavlink-router.service"
+
+    if [ -f "$SERVICE_FILE" ]; then
+        sed -i '/^\[Unit\]/a ConditionPathExists=/dev/ttyproxy' "$SERVICE_FILE"
+    fi
 }
 
 inherit meson pkgconfig systemd


### PR DESCRIPTION
Fix mavlink recipe and only start service if `/dev/ttyproxy` is available.