### PR TITLE
udev: fix synapse symlink creation

### DIFF
--- a/recipes-core/udev/udev-rules-imx/99-rpmsg.rules
+++ b/recipes-core/udev/udev-rules-imx/99-rpmsg.rules
@@ -1,7 +1,7 @@
 # Synapse
 SUBSYSTEM=="rpmsg", ACTION=="add", KERNEL=="virtio0.*", ATTR{name}=="rpmsg-synapse", RUN+="/bin/sh -c '/bin/echo /usr/bin/rpmsgexport /dev/rpmsg_ctrl0 $attr{name} $attr{src} $attr{dst} > /tmp/start-rpmsg-synapse && /bin/sh /tmp/start-rpmsg-synapse && /bin/rm /tmp/start-rpmsg-synapse'"
 SUBSYSTEM=="rpmsg", ACTION=="add", ATTR{name}=="rpmsg_ctrl", RUN+="/bin/sh /tmp/start-rpmsg-synapse"
-SUBSYSTEM=="rpmsg", KERNEL=="rpmsg0", ATTR{name}=="rpmsg-synapse", GROUP="dialout", SYMLINK+="synapse"
+SUBSYSTEM=="rpmsg", KERNEL=="rpmsg*", ATTR{name}=="rpmsg-synapse", GROUP="dialout", SYMLINK+="synapse"
 
 # Zephyr tty's
 SUBSYSTEM=="tty", KERNEL=="ttyRPMSG0", GROUP="dialout", SYMLINK+="tty-zephyr"


### PR DESCRIPTION
Synapse is not always assigned to /dev/rpmsg0 therefore a wildcard is used just as with the rpmsgfs symlink creation.