### PR TITLE
linux: update SRCBRANCH to imx95-navq-lf-6.18.y

### DIFF
--- a/recipes-kernel/linux/linux-imx_%.bbappend
+++ b/recipes-kernel/linux/linux-imx_%.bbappend
@@ -28,7 +28,7 @@ SRC_URI:append:imx8mpnavq = " \
          file://uwb.cfg \
 "
 
-SRCBRANCH = "imx95-navq-lf-6.18.y-Q2"
+SRCBRANCH = "imx95-navq-lf-6.18.y"
 SRCREV = "${AUTOREV}"
 LINUX_IMX_SRC = "git://git@github.com/NXP-Robotics/linux-imx.git;protocol=https;branch=${SRCBRANCH}"
 SRC_URI = "${LINUX_IMX_SRC}"


### PR DESCRIPTION
The old imx95-navq-lf-6.18.y-Q2 still remains in linux-imx