### PR TITLE
mcuboot: pin zephyr-sdk-native to 0.17.4 for Zephyr 4.3

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -60,6 +60,10 @@ PREFERRED_VERSION_python = "3.12.6"
 PREFERRED_VERSION_openssl = "3.0.19"
 PREFERRED_VERSION_openssl-native = "3.4.1"
 
+# zephyr-mcuboot builds Zephyr 4.3.0, which requires the 0.17.x SDK;
+# meta-zephyr's default SDK 1.0.1 only supports Zephyr 4.4 and newer
+PREFERRED_VERSION_zephyr-sdk-native = "0.17.4"
+
 LAYERSERIES_COMPAT_desktop-distro = "scarthgap walnascar whinlatter wrynose"
 
 MACHINE_FEATURES:remove = "jailhouse"


### PR DESCRIPTION
The zephyr-mcuboot recipe pins PREFERRED_VERSION_zephyr-kernel to 4.3.0, but a recipe-scoped preference cannot select the SDK, which is a global provider choice. meta-zephyr commit ec31a03 moved the default zephyr-sdk-native to 1.0.1, and SDK 1.0 declares itself incompatible with Zephyr releases older than 4.4 via ZEPHYR_SDK_MINIMUM_COMPATIBLE_VERSION. As a result the M7 multiconfig
fails do_configure out of the box:

```
CMake Error at FindZephyr-sdk.cmake:80 (find_package):
Could not find a configuration file for package "Zephyr-sdk" that is
compatible with requested version "0.16".
... Zephyr-sdkConfig.cmake, version: 1.0.1
```